### PR TITLE
v0.5.3

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -150,11 +150,14 @@ func (f *Factory) Caller(endpoint string, method string, out interface{}, opts .
 		url: &url.URL{
 			Scheme:   f.url.Scheme,
 			Host:     f.url.Host,
-			Path:     path.Join(f.url.Path, endpoint),
+			Path:     f.url.Path,
 			RawQuery: "",
 		},
 		method: method,
 		out:    out,
+	}
+	if endpoint != "" {
+		result.url.Path = path.Join(result.url.Path, endpoint)
 	}
 	newJoinCallerOption(opts...).apply(result.options)
 	return result


### PR DESCRIPTION
- bugfix: dont path join if endpoint is empty in Factory.Caller