### PR TITLE
v0.6.0

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -39,7 +39,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 	var data []byte
 	if in != nil {
 		if inValType := reflect.ValueOf(in).Type(); (inValType.Kind() == reflect.Struct ||
-			(inValType.Kind() == reflect.Pointer &&
+			(inValType.Kind() == reflect.Ptr &&
 				inValType.Elem().Kind() == reflect.Struct)) &&
 			!options.ForceBody &&
 			(c.method == http.MethodHead || c.method == http.MethodGet) {
@@ -107,7 +107,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 	}
 
 	var out interface{}
-	if outVal.Kind() == reflect.Pointer {
+	if outVal.Kind() == reflect.Ptr {
 		out = copiedOutVal.Interface()
 	} else {
 		out = copiedOutVal.Elem().Interface()

--- a/caller.go
+++ b/caller.go
@@ -74,13 +74,6 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 		Out:      nil,
 	}
 
-	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
-		err = validateJSONContentType(contentType)
-		if err != nil {
-			return result, &InvalidContentTypeError{err, contentType}
-		}
-	}
-
 	var rd io.Reader = resp.Body
 	if options.MaxResponseBodySize > 0 {
 		rd = io.LimitReader(resp.Body, options.MaxResponseBodySize)
@@ -90,6 +83,13 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 		return result, fmt.Errorf("unable to read response body: %w", err)
 	}
 	result.Data = data
+
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		err = validateJSONContentType(contentType)
+		if err != nil {
+			return result, &InvalidContentTypeError{err, contentType}
+		}
+	}
 
 	isErr := resp.StatusCode != http.StatusOK && c.options.ErrOut != nil
 

--- a/caller.go
+++ b/caller.go
@@ -46,13 +46,13 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 			var values url.Values
 			values, err = structToValues(in)
 			if err != nil {
-				return nil, &CallerError{fmt.Errorf("unable to set input to values: %w", err)}
+				return nil, fmt.Errorf("unable to set input to values: %w", err)
 			}
 			req.URL.RawQuery = values.Encode()
 		} else {
 			data, err = json.Marshal(in)
 			if err != nil {
-				return nil, &CallerError{fmt.Errorf("unable to marshal input: %w", err)}
+				return nil, fmt.Errorf("unable to marshal input: %w", err)
 			}
 			data = append(data, '\n')
 			req.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -63,7 +63,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, &CallerError{fmt.Errorf("http request error: %w", err)}
+		return nil, &RequestError{err}
 	}
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
@@ -77,7 +77,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
 		err = validateJSONContentType(contentType)
 		if err != nil {
-			return result, &CallerError{fmt.Errorf("invalid content type %q: %w", contentType, err)}
+			return result, &InvalidContentTypeError{err, contentType}
 		}
 	}
 
@@ -87,7 +87,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 	}
 	data, err = io.ReadAll(rd)
 	if err != nil {
-		return result, &CallerError{fmt.Errorf("unable to read response body: %w", err)}
+		return result, fmt.Errorf("unable to read response body: %w", err)
 	}
 	result.Data = data
 
@@ -102,7 +102,7 @@ func (c *Caller) Call(ctx context.Context, in interface{}, opts ...CallerOption)
 	if len(data) > 0 || isErr {
 		err = json.Unmarshal(data, copiedOutVal.Interface())
 		if err != nil {
-			return result, &CallerError{fmt.Errorf("unable to unmarshal response body: %w", err)}
+			return result, fmt.Errorf("unable to unmarshal response body: %w", err)
 		}
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -1,3 +1,22 @@
 package rapi
 
-type CallerError struct{ error }
+import "fmt"
+
+type RequestError struct{ error }
+
+func (e *RequestError) Error() string {
+	return fmt.Errorf("request error: %w", e.error).Error()
+}
+
+type InvalidContentTypeError struct {
+	error       error
+	contentType string
+}
+
+func (e *InvalidContentTypeError) Error() string {
+	return fmt.Errorf("invalid content type %q: %w", e.contentType, e.error).Error()
+}
+
+func (e *InvalidContentTypeError) ContentType() string {
+	return e.contentType
+}

--- a/handler.go
+++ b/handler.go
@@ -244,7 +244,7 @@ func (h *methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var in interface{}
-	if inVal.Kind() == reflect.Pointer {
+	if inVal.Kind() == reflect.Ptr {
 		in = copiedInVal.Interface()
 	} else {
 		in = copiedInVal.Elem().Interface()

--- a/utils.go
+++ b/utils.go
@@ -32,7 +32,7 @@ func httpError(r *http.Request, w http.ResponseWriter, error string, code int) {
 func validateJSONContentType(contentType string) error {
 	mediatype, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return fmt.Errorf("unable to parse media type: %w", err)
+		return fmt.Errorf("media type parse error: %w", err)
 	}
 	switch mediatype {
 	case "application/json":

--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,7 @@ func copyReflectValue(val reflect.Value) reflect.Value {
 	}
 
 	var indirectVal reflect.Value
-	if val.Kind() != reflect.Pointer {
+	if val.Kind() != reflect.Ptr {
 		indirectVal = val
 	} else {
 		if val.IsNil() {
@@ -87,7 +87,7 @@ func valuesToStruct(values url.Values, target interface{}) (err error) {
 	val := reflect.ValueOf(target)
 
 	var indirectVal reflect.Value
-	if val.Kind() != reflect.Pointer {
+	if val.Kind() != reflect.Ptr {
 		panic(errors.New("target must be struct pointer"))
 	} else {
 		if val.IsNil() {
@@ -129,14 +129,14 @@ func valuesToStruct(values url.Values, target interface{}) (err error) {
 		switch ifc.(type) {
 		case string, *string:
 			x := value
-			if kind != reflect.Pointer {
+			if kind != reflect.Ptr {
 				fieldVal.Set(reflect.ValueOf(x))
 			} else {
 				fieldVal.Set(reflect.ValueOf(&x))
 			}
 		case []byte, *[]byte:
 			x := []byte(value)
-			if kind != reflect.Pointer {
+			if kind != reflect.Ptr {
 				fieldVal.Set(reflect.ValueOf(x))
 			} else {
 				fieldVal.Set(reflect.ValueOf(&x))
@@ -160,7 +160,7 @@ func structToValues(source interface{}) (values url.Values, err error) {
 	val := reflect.ValueOf(source)
 
 	var indirectVal reflect.Value
-	if val.Kind() != reflect.Pointer {
+	if val.Kind() != reflect.Ptr {
 		indirectVal = val
 	} else {
 		if val.IsNil() {
@@ -197,19 +197,19 @@ func structToValues(source interface{}) (values url.Values, err error) {
 
 		ifc, kind := fieldVal.Interface(), fieldVal.Kind()
 
-		if kind == reflect.Pointer && fieldVal.IsNil() {
+		if kind == reflect.Ptr && fieldVal.IsNil() {
 			continue
 		}
 
 		switch ifc.(type) {
 		case string, *string:
-			if kind != reflect.Pointer {
+			if kind != reflect.Ptr {
 				values.Set(fieldName, ifc.(string))
 			} else {
 				values.Set(fieldName, *ifc.(*string))
 			}
 		case []byte, *[]byte:
-			if kind != reflect.Pointer {
+			if kind != reflect.Ptr {
 				values.Set(fieldName, string(ifc.([]byte)))
 			} else {
 				values.Set(fieldName, string(*ifc.(*[]byte)))


### PR DESCRIPTION
- replaced reflect.Pointer to reflect.Ptr for backward compatibility
- removed CallerError.
- implemented RequestError, InvalidContentTypeError.
- return InvalidContentTypeError after read data