### PR TITLE
v0.9.0

### DIFF
--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -18,7 +18,7 @@ func main() {
 		}),
 		rapi.WithMaxRequestBodySize(1<<20),
 		rapi.WithReadTimeout(60*time.Second),
-		rapi.WithResponseTimeout(60*time.Second),
+		rapi.WithWriteTimeout(60*time.Second),
 		rapi.WithAllowEncoding(true),
 	)
 

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -17,7 +17,7 @@ func main() {
 			log.Print(err)
 		}),
 		rapi.WithMaxRequestBodySize(1<<20),
-		rapi.WithRequestTimeout(60*time.Second),
+		rapi.WithReadTimeout(60*time.Second),
 		rapi.WithResponseTimeout(60*time.Second),
 		rapi.WithAllowEncoding(true),
 	)

--- a/handler.go
+++ b/handler.go
@@ -229,10 +229,10 @@ func (h *methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			rd = io.LimitReader(r.Body, h.options.MaxRequestBodySize)
 		}
 		completed := make(chan struct{})
-		if h.options.RequestTimeout > 0 {
+		if h.options.ReadTimeout > 0 {
 			go func() {
 				select {
-				case <-time.After(h.options.RequestTimeout):
+				case <-time.After(h.options.ReadTimeout):
 					_ = r.Body.Close()
 				case <-completed:
 				}

--- a/handler.go
+++ b/handler.go
@@ -171,10 +171,10 @@ func (h *methodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		respCtx, respCancel := context.WithCancel(context.Background())
 		defer respCancel()
 
-		if h.options.ResponseTimeout > 0 {
+		if h.options.WriteTimeout > 0 {
 			go func() {
 				select {
-				case <-time.After(h.options.ResponseTimeout):
+				case <-time.After(h.options.WriteTimeout):
 					respCancel()
 				case <-respCtx.Done():
 				}

--- a/handleroption.go
+++ b/handleroption.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// HandlerOption sets options such as middleware, request timeout, etc.
+// HandlerOption sets options such as middleware, read timeout, etc.
 type HandlerOption interface {
 	apply(*handlerOptions)
 }
@@ -44,7 +44,7 @@ type handlerOptions struct {
 	OnError            func(err error, req *http.Request)
 	Middleware         []MiddlewareFunc
 	MaxRequestBodySize int64
-	RequestTimeout     time.Duration
+	ReadTimeout        time.Duration
 	ResponseTimeout    time.Duration
 	AllowEncoding      bool
 }
@@ -61,7 +61,7 @@ func (o *handlerOptions) Clone() *handlerOptions {
 		OnError:            o.OnError,
 		Middleware:         make([]MiddlewareFunc, len(o.Middleware)),
 		MaxRequestBodySize: o.MaxRequestBodySize,
-		RequestTimeout:     o.RequestTimeout,
+		ReadTimeout:        o.ReadTimeout,
 		ResponseTimeout:    o.ResponseTimeout,
 		AllowEncoding:      o.AllowEncoding,
 	}
@@ -96,10 +96,10 @@ func WithMaxRequestBodySize(maxRequestBodySize int64) HandlerOption {
 	})
 }
 
-// WithRequestTimeout returns a HandlerOption that limits maximum request duration.
-func WithRequestTimeout(requestTimeout time.Duration) HandlerOption {
+// WithReadTimeout returns a HandlerOption that limits maximum request body read duration.
+func WithReadTimeout(readTimeout time.Duration) HandlerOption {
 	return newFuncHandlerOption(func(options *handlerOptions) {
-		options.RequestTimeout = requestTimeout
+		options.ReadTimeout = readTimeout
 	})
 }
 

--- a/handleroption.go
+++ b/handleroption.go
@@ -45,7 +45,7 @@ type handlerOptions struct {
 	Middleware         []MiddlewareFunc
 	MaxRequestBodySize int64
 	ReadTimeout        time.Duration
-	ResponseTimeout    time.Duration
+	WriteTimeout       time.Duration
 	AllowEncoding      bool
 }
 
@@ -62,7 +62,7 @@ func (o *handlerOptions) Clone() *handlerOptions {
 		Middleware:         make([]MiddlewareFunc, len(o.Middleware)),
 		MaxRequestBodySize: o.MaxRequestBodySize,
 		ReadTimeout:        o.ReadTimeout,
-		ResponseTimeout:    o.ResponseTimeout,
+		WriteTimeout:       o.WriteTimeout,
 		AllowEncoding:      o.AllowEncoding,
 	}
 	copy(result.Middleware, o.Middleware)
@@ -103,10 +103,10 @@ func WithReadTimeout(readTimeout time.Duration) HandlerOption {
 	})
 }
 
-// WithResponseTimeout returns a HandlerOption that limits maximum response duration.
-func WithResponseTimeout(responseTimeout time.Duration) HandlerOption {
+// WithWriteTimeout returns a HandlerOption that limits maximum response body write duration.
+func WithWriteTimeout(writeTimeout time.Duration) HandlerOption {
 	return newFuncHandlerOption(func(options *handlerOptions) {
-		options.ResponseTimeout = responseTimeout
+		options.WriteTimeout = writeTimeout
 	})
 }
 

--- a/handleroption.go
+++ b/handleroption.go
@@ -50,7 +50,9 @@ type handlerOptions struct {
 }
 
 func newHandlerOptions() (o *handlerOptions) {
-	return &handlerOptions{}
+	return &handlerOptions{
+		AllowEncoding: true,
+	}
 }
 
 func (o *handlerOptions) Clone() *handlerOptions {
@@ -111,6 +113,7 @@ func WithWriteTimeout(writeTimeout time.Duration) HandlerOption {
 }
 
 // WithAllowEncoding returns a HandlerOption that allows encoded content types such as gzip to be returned.
+// By default, encoding is allowed.
 func WithAllowEncoding(allowEncoding bool) HandlerOption {
 	return newFuncHandlerOption(func(options *handlerOptions) {
 		options.AllowEncoding = allowEncoding


### PR DESCRIPTION
- renamed WithRequestTimeout to WithReadTimeout
- renamed WithResponseTimeout to WithWriteTimeout
- allow encoding by default in Handler